### PR TITLE
Refactor myu-arena to use anyhow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,6 +205,7 @@ checksum = "c73965a44b789c468b9574bb32ae588d92d7f9509cab1b91b879e637c64274a4"
 name = "myu-arena"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "clap",
  "ctrlc",
  "myu-core",

--- a/myu-arena/Cargo.toml
+++ b/myu-arena/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+anyhow = "1.0.101"
 clap = { version = "4.5.54", features = ["derive"] }
 ctrlc = { version = "3.5.1" }
 myu-core = { path = "../myu-core" }

--- a/myu-arena/src/engine.rs
+++ b/myu-arena/src/engine.rs
@@ -15,6 +15,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use anyhow::{Context, Result};
 use myu_protocol::{EngineMsg, Limit, Sq, UserMsg, deserialize, serialize};
 
 /// A communication log entry
@@ -73,7 +74,7 @@ pub struct Engine {
     path: PathBuf,
     child: Child,
     stdin: BufWriter<ChildStdin>,
-    msg_rx: Receiver<Result<(EngineMsg, String), String>>,
+    msg_rx: Receiver<Result<(EngineMsg, String), anyhow::Error>>,
     _reader_thread: JoinHandle<()>,
     logs_dir: Option<PathBuf>,
     log: Vec<LogEntry>,
@@ -92,7 +93,7 @@ impl Engine {
         timeout_leniency: f64,
         logs_dir: Option<PathBuf>,
         stop_flag: Arc<AtomicBool>,
-    ) -> Result<Self, String> {
+    ) -> Result<Self> {
         let name = name.into();
         let mut child = Command::new(path)
             .stdin(Stdio::piped())
@@ -100,10 +101,10 @@ impl Engine {
             .stderr(Stdio::null())
             .process_group(0)
             .spawn()
-            .map_err(|e| format!("Failed to spawn {name}: {e}"))?;
+            .with_context(|| format!("Failed to spawn {name}"))?;
 
-        let stdin = child.stdin.take().ok_or("Failed to capture stdin")?;
-        let stdout = child.stdout.take().ok_or("Failed to capture stdout")?;
+        let stdin = child.stdin.take().context("Failed to capture stdin")?;
+        let stdout = child.stdout.take().context("Failed to capture stdout")?;
 
         let timeout_ms = (time_ms as f64 * timeout_leniency) as u64;
 
@@ -119,7 +120,7 @@ impl Engine {
                 match reader.read_line(&mut line) {
                     Ok(0) => {
                         // EOF - engine closed stdout
-                        _ = msg_tx.send(Err("Engine closed stdout".into()));
+                        _ = msg_tx.send(Err(anyhow::anyhow!("Engine closed stdout")));
                         break;
                     }
                     Ok(_) => {
@@ -134,14 +135,17 @@ impl Engine {
                                 }
                             }
                             Err(e) => {
-                                if msg_tx.send(Err(format!("Parse error: {e}, line: {trimmed}"))).is_err() {
+                                if msg_tx
+                                    .send(Err(anyhow::anyhow!("Parse error: {e}, line: {trimmed}")))
+                                    .is_err()
+                                {
                                     break;
                                 }
                             }
                         }
                     }
                     Err(e) => {
-                        _ = msg_tx.send(Err(format!("Read error: {e}")));
+                        _ = msg_tx.send(Err(anyhow::anyhow!("Read error: {e}")));
                         break;
                     }
                 }
@@ -169,7 +173,7 @@ impl Engine {
         Ok(engine)
     }
 
-    fn wait_for_id(&mut self) -> Result<(), String> {
+    fn wait_for_id(&mut self) -> Result<()> {
         // Engines should send Id message immediately on startup
         match self.msg_rx.recv_timeout(Duration::from_secs(5)) {
             Ok(Ok((msg @ EngineMsg::Id { .. }, raw))) => {
@@ -181,11 +185,15 @@ impl Engine {
             }
             Ok(Ok((msg, raw))) => {
                 self.log_received(&raw);
-                Err(format!("Engine {} sent {:?} instead of Id", self.name, msg))
+                Err(anyhow::anyhow!("Engine {} sent {:?} instead of Id", self.name, msg))
             }
             Ok(Err(e)) => Err(e),
-            Err(RecvTimeoutError::Timeout) => Err(format!("Engine {} did not send Id message (timeout)", self.name)),
-            Err(RecvTimeoutError::Disconnected) => Err(format!("Engine {} reader disconnected", self.name)),
+            Err(RecvTimeoutError::Timeout) => {
+                Err(anyhow::anyhow!("Engine {} did not send Id message (timeout)", self.name))
+            }
+            Err(RecvTimeoutError::Disconnected) => {
+                Err(anyhow::anyhow!("Engine {} reader disconnected", self.name))
+            }
         }
     }
 
@@ -225,15 +233,15 @@ impl Engine {
         }
     }
 
-    fn send_message(&mut self, msg: &UserMsg) -> Result<(), String> {
-        let line = serialize(msg).map_err(|e| format!("Serialization error: {e}"))?;
+    fn send_message(&mut self, msg: &UserMsg) -> Result<()> {
+        let line = serialize(msg).context("Serialization error")?;
         self.log(LogDirection::Sent, &line);
-        writeln!(self.stdin, "{line}").map_err(|e| format!("Write error: {e}"))?;
-        self.stdin.flush().map_err(|e| format!("Flush error: {e}"))?;
+        writeln!(self.stdin, "{line}").context("Write error")?;
+        self.stdin.flush().context("Flush error")?;
         Ok(())
     }
 
-    fn recv_message_timeout(&mut self, timeout: Duration) -> Result<Option<EngineMsg>, String> {
+    fn recv_message_timeout(&mut self, timeout: Duration) -> Result<Option<EngineMsg>> {
         match self.msg_rx.recv_timeout(timeout) {
             Ok(Ok((msg, raw))) => {
                 self.log_received(&raw);
@@ -241,18 +249,18 @@ impl Engine {
             }
             Ok(Err(e)) => Err(e),
             Err(RecvTimeoutError::Timeout) => Ok(None),
-            Err(RecvTimeoutError::Disconnected) => Err("Engine reader disconnected".into()),
+            Err(RecvTimeoutError::Disconnected) => Err(anyhow::anyhow!("Engine reader disconnected")),
         }
     }
 
     /// Send Sync command and wait for Ready
-    pub fn sync(&mut self) -> Result<(), String> {
+    pub fn sync(&mut self) -> Result<()> {
         self.send_message(&UserMsg::Sync)?;
         self.wait_for_ready()
     }
 
     /// Reset the engine for a new game
-    pub fn reset(&mut self) -> Result<(), String> {
+    pub fn reset(&mut self) -> Result<()> {
         self.send_message(&UserMsg::Reset)?;
         self.send_message(&UserMsg::Sync)?;
         self.wait_for_ready()?;
@@ -262,12 +270,12 @@ impl Engine {
         Ok(())
     }
 
-    fn wait_for_ready(&mut self) -> Result<(), String> {
+    fn wait_for_ready(&mut self) -> Result<()> {
         let deadline = Instant::now() + Duration::from_millis(self.timeout_ms);
         loop {
             let remaining = deadline.saturating_duration_since(Instant::now());
             if remaining.is_zero() {
-                return Err(format!("Engine {} did not respond to Sync", self.name));
+                return Err(anyhow::anyhow!("Engine {} did not respond to Sync", self.name));
             }
             match self.recv_message_timeout(remaining)? {
                 Some(EngineMsg::Ready) => return Ok(()),
@@ -281,7 +289,7 @@ impl Engine {
     }
 
     /// Send Play command
-    pub fn play(&mut self, moves: Vec<Sq>) -> Result<(), String> {
+    pub fn play(&mut self, moves: Vec<Sq>) -> Result<()> {
         self.send_message(&UserMsg::Play(moves))
     }
 

--- a/myu-arena/src/main.rs
+++ b/myu-arena/src/main.rs
@@ -16,6 +16,7 @@ use std::{
     time::Instant,
 };
 
+use anyhow::{Context, Result};
 use clap::Parser;
 use cli::{Cli, Commands, TestArgs};
 use gsprt::{GsprtResult, SprtState};
@@ -24,7 +25,7 @@ use myu_core::{MvFormat, PgnFormat, format_game};
 use opening_book::OpeningBook;
 use stats::MatchStats;
 
-fn main() {
+fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
@@ -33,27 +34,22 @@ fn main() {
     }
 }
 
-fn gen_book(count: usize, depth: usize, output: PathBuf) {
+fn gen_book(count: usize, depth: usize, output: PathBuf) -> Result<()> {
     println!("Generating {count} openings of depth {depth}...");
     let book = OpeningBook::generate_random(count, depth);
-    match book.save_to_file(&output) {
-        Ok(()) => println!("Opening book saved to {}", output.display()),
-        Err(e) => {
-            eprintln!("Error saving opening book: {e}");
-            std::process::exit(1);
-        }
-    }
+    book.save_to_file(&output).context("Error saving opening book")?;
+    println!("Opening book saved to {}", output.display());
+    Ok(())
 }
 
-fn run_test(args: TestArgs) {
+fn run_test(args: TestArgs) -> Result<()> {
     if args.elo0 >= args.elo1 {
-        eprintln!("Error: elo0 must be less than elo1");
-        std::process::exit(1);
+        anyhow::bail!("elo0 must be less than elo1");
     }
 
-    setup_logging(&args);
-    let opening_book = load_opening_book(&args);
-    let games_writer = setup_games_writer(&args);
+    setup_logging(&args)?;
+    let opening_book = load_opening_book(&args)?;
+    let games_writer = setup_games_writer(&args)?;
     let stop_flag = setup_ctrlc_handler();
 
     let mut stats = MatchStats::default();
@@ -107,35 +103,34 @@ fn run_test(args: TestArgs) {
     }
 
     print_final_results(&stats, &sprt, completed_pairs, start_time.elapsed());
+    Ok(())
 }
 
-fn setup_logging(args: &TestArgs) {
-    if let Some(ref logs_dir) = args.logs_dir
-        && let Err(e) = fs::create_dir_all(logs_dir)
-    {
-        eprintln!("Error creating logs directory: {e}");
-        std::process::exit(1);
+fn setup_logging(args: &TestArgs) -> Result<()> {
+    if let Some(ref logs_dir) = args.logs_dir {
+        fs::create_dir_all(logs_dir).context("Error creating logs directory")?;
     }
+    Ok(())
 }
 
-fn load_opening_book(args: &TestArgs) -> OpeningBook {
+fn load_opening_book(args: &TestArgs) -> Result<OpeningBook> {
     match &args.opening_book {
-        Some(path) => OpeningBook::from_file(path).unwrap_or_else(|e| {
-            eprintln!("Error loading opening book: {e}");
-            std::process::exit(1);
-        }),
-        None => OpeningBook::empty(),
+        Some(path) => OpeningBook::from_file(path).context("Error loading opening book"),
+        None => Ok(OpeningBook::empty()),
     }
 }
 
-fn setup_games_writer(args: &TestArgs) -> Option<Arc<Mutex<BufWriter<File>>>> {
-    args.games_file.as_ref().map(|path| {
-        let file = OpenOptions::new().create(true).append(true).open(path).unwrap_or_else(|e| {
-            eprintln!("Error opening games file: {e}");
-            std::process::exit(1);
-        });
-        Arc::new(Mutex::new(BufWriter::new(file)))
-    })
+fn setup_games_writer(args: &TestArgs) -> Result<Option<Arc<Mutex<BufWriter<File>>>>> {
+    if let Some(path) = &args.games_file {
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .context("Error opening games file")?;
+        Ok(Some(Arc::new(Mutex::new(BufWriter::new(file)))))
+    } else {
+        Ok(None)
+    }
 }
 
 fn setup_ctrlc_handler() -> Arc<AtomicBool> {

--- a/myu-arena/src/match_runner.rs
+++ b/myu-arena/src/match_runner.rs
@@ -11,6 +11,7 @@ use std::{
     thread,
 };
 
+use anyhow::Result;
 use myu_core::{Color, Game, Mv, Outcome};
 
 use crate::{
@@ -178,7 +179,7 @@ impl ManagedEngine {
     }
 
     /// Ensure the engine is ready to play. Spawns if needed.
-    fn ensure_ready(&mut self, config: &GameConfig) -> Result<&mut Engine, String> {
+    fn ensure_ready(&mut self, config: &GameConfig) -> Result<&mut Engine> {
         if self.engine.is_none() {
             let mut engine = Engine::spawn(
                 self.role.name(),
@@ -474,14 +475,14 @@ fn play_single_game(
     interpret_result(raw, dev_is_white, white_role, black_role, dev, base)
 }
 
-fn spawn_error(failed_role: EngineRole, error: String) -> GameResult {
+fn spawn_error(failed_role: EngineRole, error: anyhow::Error) -> GameResult {
     let dev_failed = failed_role == EngineRole::Dev;
     GameResult {
         game: Game::new(),
         dev_score: if dev_failed { Score::Loss } else { Score::Win },
         termination: Some(Termination {
             kind: TerminationKind::SpawnFailed,
-            details: error,
+            details: format!("{error:#}"),
             faulty_engine: Some(failed_role.as_faulty()),
         }),
     }

--- a/myu-arena/src/opening_book.rs
+++ b/myu-arena/src/opening_book.rs
@@ -6,6 +6,7 @@ use std::{
     path::Path,
 };
 
+use anyhow::{Context, Result};
 use myu_core::{Mv, State, parse_sq};
 
 /// Opening book: a collection of opening move sequences
@@ -21,13 +22,13 @@ impl OpeningBook {
 
     /// Load opening book from file
     /// Format: one opening per line, space-separated move sequence (e.g., "d4 d5 c4 e6")
-    pub fn from_file(path: &Path) -> Result<Self, String> {
-        let file = File::open(path).map_err(|e| format!("Failed to open {}: {e}", path.display()))?;
+    pub fn from_file(path: &Path) -> Result<Self> {
+        let file = File::open(path).with_context(|| format!("Failed to open {}", path.display()))?;
         let reader = BufReader::new(file);
         let mut openings = Vec::new();
 
         for (line_num, line) in reader.lines().enumerate() {
-            let line = line.map_err(|e| format!("Read error at line {}: {e}", line_num + 1))?;
+            let line = line.with_context(|| format!("Read error at line {}", line_num + 1))?;
             let line = line.trim();
 
             if line.is_empty() || line.starts_with('#') {
@@ -37,7 +38,12 @@ impl OpeningBook {
             let mut moves = Vec::new();
             for (move_idx, move_str) in line.split_whitespace().enumerate() {
                 let sq = parse_sq(move_str).map_err(|e| {
-                    format!("Invalid move '{}' at line {} position {}: {e}", move_str, line_num + 1, move_idx + 1)
+                    anyhow::anyhow!(
+                        "Invalid move '{}' at line {} position {}: {e}",
+                        move_str,
+                        line_num + 1,
+                        move_idx + 1
+                    )
                 })?;
                 moves.push(Mv::new(sq));
             }
@@ -85,7 +91,7 @@ impl OpeningBook {
     }
 
     /// Validate all openings by replaying them from the initial position
-    fn validate(&mut self) -> Result<(), String> {
+    fn validate(&mut self) -> Result<()> {
         let mut invalid_indices = Vec::new();
 
         for (idx, opening) in self.openings.iter().enumerate() {
@@ -102,42 +108,47 @@ impl OpeningBook {
 
         // Ensure we still have at least one opening
         if self.openings.is_empty() {
-            return Err("No valid openings in book after validation".into());
+            return Err(anyhow::anyhow!("No valid openings in book after validation"));
         }
 
         Ok(())
     }
 
     /// Validate a single opening by replaying it from the initial position
-    fn validate_opening(opening: &[Mv]) -> Result<(), String> {
+    fn validate_opening(opening: &[Mv]) -> Result<()> {
         let mut state = State::new();
 
         for (move_idx, mv) in opening.iter().enumerate() {
             match state.play(*mv) {
                 Ok((new_state, _)) => state = new_state,
                 Err(e) => {
-                    return Err(format!("move {} ({}): {}", move_idx + 1, myu_core::format_sq(mv.sq), e));
+                    return Err(anyhow::anyhow!(
+                        "move {} ({}): {}",
+                        move_idx + 1,
+                        myu_core::format_sq(mv.sq),
+                        e
+                    ));
                 }
             }
         }
 
         // Check if the position is still playable (not a terminal position)
         if state.legal_moves().next().is_none() {
-            return Err("opening leads to terminal position".into());
+            return Err(anyhow::anyhow!("opening leads to terminal position"));
         }
 
         Ok(())
     }
 
     /// Save opening book to file
-    pub fn save_to_file(&self, path: &Path) -> Result<(), String> {
+    pub fn save_to_file(&self, path: &Path) -> Result<()> {
         use std::io::Write;
 
-        let mut file = File::create(path).map_err(|e| format!("Failed to create {}: {e}", path.display()))?;
+        let mut file = File::create(path).with_context(|| format!("Failed to create {}", path.display()))?;
 
         for opening in &self.openings {
             let line: String = opening.iter().map(|mv| myu_core::format_sq(mv.sq)).collect::<Vec<_>>().join(" ");
-            writeln!(file, "{}", line).map_err(|e| format!("Write error: {e}"))?;
+            writeln!(file, "{}", line).context("Write error")?;
         }
 
         Ok(())


### PR DESCRIPTION
Refactored `myu-arena` to use `anyhow` for robust error handling. This includes updating `Cargo.toml`, and modifying `engine.rs`, `opening_book.rs`, `match_runner.rs`, and `main.rs` to leverage `anyhow::Result` and `Context` traits. Replaced manual error printing and process exiting with proper error propagation.

---
*PR created automatically by Jules for task [3728664033462374953](https://jules.google.com/task/3728664033462374953) started by @alion02*