### PR TITLE
⚡ Async I/O for Config Reload in Myu-Bridge

### DIFF
--- a/myu-bridge/Cargo.toml
+++ b/myu-bridge/Cargo.toml
@@ -11,6 +11,6 @@ reqwest = { version = "0.13.2", features = ["json"] }
 rust_socketio = { version = "0.6.0", features = ["async"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-tokio = { version = "1.49.0", features = ["macros", "rt-multi-thread", "time", "process", "signal"] }
+tokio = { version = "1.49.0", features = ["macros", "rt-multi-thread", "time", "process", "signal", "fs"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }

--- a/myu-bridge/src/controller.rs
+++ b/myu-bridge/src/controller.rs
@@ -100,7 +100,8 @@ impl Controller {
         let mut ping_interval = tokio::time::interval_at(Instant::now() + PING_INTERVAL, PING_INTERVAL);
 
         let mut config_interval = tokio::time::interval(Duration::from_secs(1));
-        let mut last_config_mod = std::fs::metadata(&self.config_path)
+        let mut last_config_mod = tokio::fs::metadata(&self.config_path)
+            .await
             .and_then(|m| m.modified())
             .unwrap_or_else(|_| std::time::SystemTime::now());
 
@@ -126,7 +127,7 @@ impl Controller {
                 }
 
                 _ = config_interval.tick() => {
-                    if let Ok(modified) = std::fs::metadata(&self.config_path).and_then(|m| m.modified())
+                    if let Ok(modified) = tokio::fs::metadata(&self.config_path).await.and_then(|m| m.modified())
                         && modified > last_config_mod
                     {
                         last_config_mod = modified;


### PR DESCRIPTION
💡 **What:**
Replaced the synchronous `std::fs::metadata` call with the asynchronous `tokio::fs::metadata` in `myu-bridge/src/controller.rs` and enabled the `fs` feature in `tokio` (Cargo.toml).

🎯 **Why:**
The previous implementation used a blocking filesystem call inside the main async event loop of the bridge controller. In high-load scenarios or on slow filesystems (e.g., network mounts), this could block the thread and delay the processing of latency-sensitive socket events or engine messages.

📊 **Measured Improvement:**
A synthetic benchmark (`bench_blocking.rs`) was created to simulate the impact of blocking I/O on a concurrent high-frequency task (simulating 1ms event ticks).
- **Blocking (Baseline):** 343 µs max latency spike (on fast local NVMe).
- **Async (Optimized):** 2137 µs max latency spike.

**Note on Benchmark Results:**
Counter-intuitively, the *blocking* call was faster in the micro-benchmark on this specific environment likely due to OS-level file caching making the syscall effectively instant, whereas `tokio::fs` introduces overhead from offloading to a thread pool and context switching.

**Rationale for Change despite Benchmark:**
Despite the micro-benchmark result, this change is a **correctness and robustness optimization**. The "fast path" of a cached file metadata check is misleading; if the file were on a slow medium or the kernel cache was cold, `std::fs::metadata` could block for milliseconds or tens of milliseconds, completely freezing the single-threaded async runtime. The `tokio::fs` approach guarantees that *no matter how slow the I/O is*, the event loop will not be blocked, ensuring consistent latency for game moves and heartbeats.

Verification:
- `cargo check -p myu-bridge` passes.
- `cargo test -p myu-bridge` passes.

---
*PR created automatically by Jules for task [8876993778667458329](https://jules.google.com/task/8876993778667458329) started by @alion02*