### PR TITLE
⚡ Async Config Reloading in Myu-Bridge

### DIFF
--- a/myu-bridge/Cargo.toml
+++ b/myu-bridge/Cargo.toml
@@ -11,6 +11,6 @@ reqwest = { version = "0.13.2", features = ["json"] }
 rust_socketio = { version = "0.6.0", features = ["async"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-tokio = { version = "1.49.0", features = ["macros", "rt-multi-thread", "time", "process", "signal"] }
+tokio = { version = "1.49.0", features = ["macros", "rt-multi-thread", "time", "process", "signal", "fs"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }

--- a/myu-bridge/src/config.rs
+++ b/myu-bridge/src/config.rs
@@ -15,8 +15,10 @@ pub struct AcceptRule {
     pub engine_set: Option<serde_json::Value>,
 }
 
-pub fn parse_config(path: &std::path::Path) -> Result<BridgeConfig> {
-    let content = std::fs::read_to_string(path).with_context(|| format!("Failed to read config file at {:?}", path))?;
+pub async fn parse_config(path: &std::path::Path) -> Result<BridgeConfig> {
+    let content = tokio::fs::read_to_string(path)
+        .await
+        .with_context(|| format!("Failed to read config file at {:?}", path))?;
 
     let doc: KdlDocument = content.parse().context("Failed to parse KDL config")?;
     let mut accept_rules = Vec::new();

--- a/myu-bridge/src/controller.rs
+++ b/myu-bridge/src/controller.rs
@@ -100,7 +100,8 @@ impl Controller {
         let mut ping_interval = tokio::time::interval_at(Instant::now() + PING_INTERVAL, PING_INTERVAL);
 
         let mut config_interval = tokio::time::interval(Duration::from_secs(1));
-        let mut last_config_mod = std::fs::metadata(&self.config_path)
+        let mut last_config_mod = tokio::fs::metadata(&self.config_path)
+            .await
             .and_then(|m| m.modified())
             .unwrap_or_else(|_| std::time::SystemTime::now());
 
@@ -126,17 +127,19 @@ impl Controller {
                 }
 
                 _ = config_interval.tick() => {
-                    if let Ok(modified) = std::fs::metadata(&self.config_path).and_then(|m| m.modified())
-                        && modified > last_config_mod
-                    {
-                        last_config_mod = modified;
-                        match crate::config::parse_config(&self.config_path) {
-                            Ok(cfg) => {
-                                tracing::info!("Config file modified. Reloaded {} rules.", cfg.accept_rules.len());
-                                self.config_rules = cfg.accept_rules;
-                            }
-                            Err(e) => {
-                                tracing::error!("Failed to reload config: {}", e);
+                    if let Ok(metadata) = tokio::fs::metadata(&self.config_path).await {
+                        if let Ok(modified) = metadata.modified() {
+                            if modified > last_config_mod {
+                                last_config_mod = modified;
+                                match crate::config::parse_config(&self.config_path).await {
+                                    Ok(cfg) => {
+                                        tracing::info!("Config file modified. Reloaded {} rules.", cfg.accept_rules.len());
+                                        self.config_rules = cfg.accept_rules;
+                                    }
+                                    Err(e) => {
+                                        tracing::error!("Failed to reload config: {}", e);
+                                    }
+                                }
                             }
                         }
                     }

--- a/myu-bridge/src/main.rs
+++ b/myu-bridge/src/main.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<()> {
     let password = std::env::var("MIGOYUGO_PASSWORD").context("MIGOYUGO_PASSWORD environment variable is required")?;
 
     let config_path = std::path::Path::new(&args.config);
-    let bridge_config = config::parse_config(config_path)?;
+    let bridge_config = config::parse_config(config_path).await?;
     tracing::info!("Loaded {} config rules", bridge_config.accept_rules.len());
 
     let mut http_client = MigoyugoHttpClient::new(&args.url);


### PR DESCRIPTION
This PR optimizes the configuration reloading mechanism in `myu-bridge`. 

Previously, `parse_config` and the file modification check used synchronous `std::fs` calls inside the async `Controller` loop. This would block the OS thread running the tokio runtime, potentially causing latency spikes for other tasks or preventing immediate handling of socket events if the disk I/O was slow (e.g. large file or busy disk).

The changes include:
1.  Making `parse_config` async and using `tokio::fs::read_to_string`.
2.  Updating the `Controller` loop to use `tokio::fs::metadata` for checking file modification time.
3.  Updating call sites to `.await` these operations.

This ensures that I/O operations yield to the tokio runtime, allowing other tasks to be scheduled while waiting for the disk.

---
*PR created automatically by Jules for task [15147164310990804598](https://jules.google.com/task/15147164310990804598) started by @alion02*